### PR TITLE
Add cv::cuda::GpuMat overloads for extractAndResizeROI, runInference

### DIFF
--- a/include/engine/EngineRunInference.inl
+++ b/include/engine/EngineRunInference.inl
@@ -275,9 +275,11 @@ bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &i
 template <typename T>
 bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output) {
     cv::cuda::GpuMat gpuOutput;
-    bool result = runInference(inputs, gpuOutput);
-    gpuOutput.download(output);
-    return result;
+    bool didSucceed = runInference(inputs, gpuOutput);
+    if (didSucceed) {
+        gpuOutput.download(output);
+    }
+    return didSucceed;
 }
 
 

--- a/include/engine/EngineRunInference.inl
+++ b/include/engine/EngineRunInference.inl
@@ -271,8 +271,9 @@ bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &i
 template <typename T>
 bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output) {
     cv::cuda::GpuMat gpuOutput;
-    runInference(inputs, gpuOutput);
+    bool result = runInference(inputs, gpuOutput);
     gpuOutput.download(output);
+    return result;
 }
 
 

--- a/include/engine/EngineUtilities.inl
+++ b/include/engine/EngineUtilities.inl
@@ -35,6 +35,12 @@ int Engine<T>::constrainToMultipleOf(const float x, const int multiple, const in
 }
 
 template <typename T>
+void Engine<T>::extractAndResizeROI(const cv::cuda::GpuMat &input, cv::cuda::GpuMat &output, size_t roi_h, size_t roi_w, size_t height, size_t width) {
+    cv::cuda::GpuMat roi(input, cv::Rect(0, 0, roi_w, roi_h));
+    cv::cuda::resize(roi, output, cv::Size(width, height), 0, 0, cv::INTER_LINEAR);
+}
+
+template <typename T>
 void Engine<T>::extractAndResizeROI(const cv::Mat &input, cv::Mat &output, size_t roi_h, size_t roi_w, size_t height, size_t width) {
     cv::Mat roi = input(cv::Rect(0, 0, roi_w, roi_h));
     cv::resize(roi, output, cv::Size(width, height), 0, 0, cv::INTER_LINEAR);

--- a/include/interfaces/IEngine.h
+++ b/include/interfaces/IEngine.h
@@ -16,6 +16,8 @@ public:
     virtual bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, 
                               std::vector<std::vector<std::vector<T>>> &featureVectors) = 0;
     virtual bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, 
+                              cv::cuda::GpuMat &output) = 0;
+    virtual bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, 
                               cv::Mat &output) = 0;
     virtual bool runInference(const cv::Mat &input, cv::Mat &output) = 0;
     virtual bool runInferenceCUDA(const std::vector<int> &inputShape, T *input, cv::Mat &output) = 0;

--- a/src/engine.h
+++ b/src/engine.h
@@ -93,7 +93,7 @@ public:
     // Run inference.
     // Input format [input][batch][cv::cuda::GpuMat]
     // Output format [cv::Mat]
-    bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output);
+    bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output) override;
     bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output) override;
 
     // Run inference.

--- a/src/engine.h
+++ b/src/engine.h
@@ -93,8 +93,8 @@ public:
     // Run inference.
     // Input format [input][batch][cv::cuda::GpuMat]
     // Output format [cv::Mat]
+    bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output);
     bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output) override;
-
 
     // Run inference.
     // Input format [cv::Mat]
@@ -124,6 +124,7 @@ public:
     // Utility method for extracting an ROI from an image and rescaling it to the specified dimensions.
     // The ROI is extracted from the top left of the image. This function is the complement of 
     // the above function for networks that predict output maps.
+    static void extractAndResizeROI(const cv::cuda::GpuMat &input, cv::cuda::GpuMat &output, size_t roi_h, size_t roi_w, size_t height, size_t width);
     static void extractAndResizeROI(const cv::Mat &input, cv::Mat &output, size_t roi_h, size_t roi_w, size_t height, size_t width);
 
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -92,8 +92,12 @@ public:
 
     // Run inference.
     // Input format [input][batch][cv::cuda::GpuMat]
-    // Output format [cv::Mat]
+    // Output format [cv::cuda::GpuMat]
     bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output) override;
+
+    // Run inference.
+    // Input format [input][batch][cv::cuda::GpuMat]
+    // Output format [cv::Mat]
     bool runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output) override;
 
     // Run inference.
@@ -157,6 +161,11 @@ private:
     void getDeviceNames(std::vector<std::string> &deviceNames);
 
     void clearGpuBuffers();
+
+    // Run inference. Output GpuMat wraps an internal data buffer and should be cloned or downloaded immediately.
+    // Input format [input][batch][cv::cuda::GpuMat]
+    // Output format [cv::cuda::GpuMat]
+    bool runInferenceWithNoGpuCopy(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output);
 
     // Normalization, scaling, and mean subtraction of inputs
     std::array<float, 3> m_subVals{};


### PR DESCRIPTION
Overloads:
- variant of `extractAndResizeROI `with `cv::cuda::GpuMat` for input/output args
- inference function `bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::Mat &output)` now has an overload `bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &inputs, cv::cuda::GpuMat &output)` to allow keeping the output image on GPU for further processing. The original function now wraps the GPU variant with minimal overhead.